### PR TITLE
allow `monthreshold` override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of netscaler.
 
+## 1.0.4
+- Add: new `monthreshold` option for the payload.
+
 ## 1.0.3
 - Hotfix: `rest_client` gem removed from rubygems.org, use `rest-client` gem
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'dl_teamengineering@daptiv.com'
 license          'All rights reserved'
 description      'A collection of resources for managing Citrix NetScaler'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.3'
+version          '1.0.4'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          'All rights reserved'
 description      'A collection of resources for managing Citrix NetScaler'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.4'
+issues_url 'https://github.com/daptiv/netscaler/issues'
+source_url 'https://github.com/daptiv/netscaler/'

--- a/providers/servicegroup.rb
+++ b/providers/servicegroup.rb
@@ -36,6 +36,7 @@ action :create do
     cachetype: @new_resource.cachetype,
     autoscale: @new_resource.autoscale,
     monstate: @new_resource.monstate,
+    monthreshold: @new_resource.monthreshold,
     healthmonitor: @new_resource.healthmonitor,
     appflowlog: @new_resource.appflowlog,
     comment: @new_resource.comment

--- a/resources/servicegroup.rb
+++ b/resources/servicegroup.rb
@@ -41,3 +41,4 @@ attribute :customserverid, :kind_of => String, :required => false, :default => n
 attribute :hashid, :kind_of => String, :required => false, :default => nil
 attribute :cip, :kind_of => String, :required => false, :default => nil
 attribute :cipheader, :kind_of => String, :required => false, :default => nil
+attribute :monthreshold, :kind_of => String, :required => false, :default => nil


### PR DESCRIPTION
@linusruth New `monthreshold` option for the payload (needed for having multiple monitors assigned to a single servicegroup).